### PR TITLE
feat: Add new analysis tools and prompts

### DIFF
--- a/NEW_PROMPTS.md
+++ b/NEW_PROMPTS.md
@@ -1,0 +1,117 @@
+# New Prompts for Zabbix MCP Server
+
+This file outlines new prompts that can be used with the Zabbix MCP Server, leveraging the newly created analysis tools.
+
+## 1. Host Diagnostics Prompt
+
+**Prompt:** `zabbix_host_diagnostics_report`
+
+**Description:**
+Provides a comprehensive diagnostic report for a single host. This is useful for deep-dive investigations into a specific host's performance and status.
+
+**Example Usage (Claude Desktop):**
+```json
+{
+  "hostIdentifier": "zabbix-server",
+  "historyItemKeys": [
+    "system.cpu.util[,idle]",
+    "vm.memory.size[available]",
+    "zabbix[queue,5m]"
+  ]
+}
+```
+
+**LLM Conversation Example:**
+```
+User: "Run a full diagnostic on the zabbix-server."
+Assistant: "I'll generate a comprehensive diagnostic report for 'zabbix-server', including its configuration, active problems, and recent performance history for key metrics."
+
+[Uses zabbix_get_host_diagnostics tool]
+
+**Host Diagnostics Report: zabbix-server**
+- **Host Details:** (JSON output of host properties)
+- **Active Problems:** (List of current problems on the host)
+- **Recent History:** (Recent data for the specified items)
+```
+
+## 2. Host Comparison Prompt
+
+**Prompt:** `zabbix_compare_host_configurations`
+
+**Description:**
+Compares the configurations of two hosts, highlighting differences in templates, macros, and interfaces. This is ideal for troubleshooting "works on my machine" type issues.
+
+**Example Usage (Claude Desktop):**
+```json
+{
+  "hostIdentifierA": "web-server-01",
+  "hostIdentifierB": "web-server-02"
+}
+```
+
+**LLM Conversation Example:**
+```
+User: "Why is web-server-01 behaving differently from web-server-02? Compare their configurations."
+Assistant: "I will compare the configurations of 'web-server-01' and 'web-server-02' to identify any differences."
+
+[Uses zabbix_compare_hosts tool]
+
+**Configuration Difference: web-server-01 vs web-server-02**
+(A diff patch showing the differences in JSON configuration)
+```
+
+## 3. Unmonitored Hosts Audit Prompt
+
+**Prompt:** `zabbix_audit_unmonitored_hosts_report`
+
+**Description:**
+Performs an audit to find hosts that are not being monitored correctly. This is useful for ensuring complete monitoring coverage.
+
+**Example Usage (Claude Desktop):**
+```json
+{
+  "hostGroupIds": ["2"]
+}
+```
+
+**LLM Conversation Example:**
+```
+User: "Are there any hosts in the 'Linux Servers' group that we're not monitoring?"
+Assistant: "I will audit the hosts in the specified group to find any that are unmonitored or have availability issues."
+
+[Uses zabbix_audit_unmonitored_hosts tool]
+
+**Unmonitored Hosts Audit Report**
+- **Unmonitored Hosts:** (List of hosts with status 'unmonitored')
+- **Hosts with Availability Errors:** (List of hosts with Zabbix agent reachability issues)
+- **Summary:** (Counts of audited hosts and issues found)
+```
+
+## 4. Template Audit Prompt
+
+**Prompt:** `zabbix_template_health_check`
+
+**Description:**
+Analyzes the health of template configurations, identifying unused templates, hosts without templates, and potentially bloated templates.
+
+**Example Usage (Claude Desktop):**
+```json
+{
+  "itemThreshold": 150,
+  "triggerThreshold": 75
+}
+```
+
+**LLM Conversation Example:**
+```
+User: "Let's clean up our templates. Run a template health check."
+Assistant: "I will perform an audit of your Zabbix templates to identify any that are unlinked, oversized, or any hosts that are missing templates."
+
+[Uses zabbix_template_audit tool]
+
+**Template Audit Report**
+- **Unlinked Templates:** (Templates not assigned to any hosts)
+- **Hosts Without Templates:** (Hosts that are not using any templates)
+- **Oversized Templates:** (Templates exceeding the item/trigger thresholds)
+- **Summary:** (Counts of templates, hosts, and identified issues)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "zabbix-mcp-server-nodejs",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zabbix-mcp-server-nodejs",
-      "version": "2.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.3",
         "axios": "^1.9.0",
+        "diff": "^8.0.2",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "winston": "^3.17.0",
@@ -4025,10 +4026,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -8716,6 +8716,16 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.3",
     "axios": "^1.9.0",
+    "diff": "^8.0.2",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "winston": "^3.17.0",

--- a/src/tools/analysis.js
+++ b/src/tools/analysis.js
@@ -1,0 +1,284 @@
+const api = require('../api');
+const { logger } = require('../utils/logger');
+const { z } = require('zod');
+const schemas = require('./schemas');
+const diff = require('diff');
+
+// Helper function to resolve host identifiers (ID, technical name, visible name, or IP) to host IDs
+async function resolveHostIdentifier(identifier) {
+    if (!identifier) {
+        return { hostId: null, error: "No host identifier provided." };
+    }
+
+    // Check if it's a numeric ID
+    if (/^\d+$/.test(identifier)) {
+        const hostById = await api.getHosts({ hostids: [identifier], output: ["hostid"] });
+        if (hostById && hostById.length > 0) {
+            return { hostId: identifier, error: null };
+        }
+    }
+
+    // Check if it's an IP address
+    if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$|([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}/.test(identifier)) {
+        const interfaces = await api.getHostInterfaces({
+            filter: { ip: identifier },
+            output: ["hostid"]
+        });
+        if (interfaces && interfaces.length > 0) {
+            return { hostId: interfaces[0].hostid, error: null };
+        }
+    }
+
+    // Check by technical name or visible name
+    let hosts = await api.getHosts({
+        filter: { host: [identifier] },
+        output: ["hostid"]
+    });
+    if (hosts && hosts.length > 0) {
+        return { hostId: hosts[0].hostid, error: null };
+    }
+
+    hosts = await api.getHosts({
+        filter: { name: [identifier] },
+        output: ["hostid"]
+    });
+    if (hosts && hosts.length > 0) {
+        return { hostId: hosts[0].hostid, error: null };
+    }
+
+    return { hostId: null, error: `Could not resolve identifier '${identifier}' to a host ID.` };
+}
+
+
+function registerTools(server) {
+    // Tool: Get Host Diagnostics
+    server.tool(
+        'zabbix_get_host_diagnostics',
+        'Retrieves a comprehensive diagnostic report for a single host, including its properties, problems, and recent history for key items.',
+        {
+            hostIdentifier: z.string().describe("The technical name, visible name, IP address, or ID of the host to diagnose."),
+            historyItemKeys: z.array(z.string()).optional().describe("An array of item keys (e.g., system.cpu.load[,avg1]) to retrieve history for. Defaults to common CPU, memory, and network items if not provided.")
+        },
+        async ({ hostIdentifier, historyItemKeys }) => {
+            try {
+                const { hostId, error } = await resolveHostIdentifier(hostIdentifier);
+
+                if (error) {
+                    return { content: [{ type: 'text', text: error }] };
+                }
+
+                // 1. Get Host Details
+                const hosts = await api.getHosts({
+                    hostids: [hostId],
+                    selectInterfaces: 'extend',
+                    selectParentTemplates: 'extend',
+                    selectMacros: 'extend',
+                    selectInventory: 'extend',
+                    selectTriggers: 'count',
+                    selectItems: 'count'
+                });
+
+                if (!hosts || hosts.length === 0) {
+                    return { content: [{ type: 'text', text: `Host with ID '${hostId}' not found.` }] };
+                }
+                const hostDetails = hosts[0];
+
+                // 2. Get Active Problems for the host
+                const problems = await api.getProblems({
+                    hostids: [hostId],
+                    sortfield: ["clock"],
+                    sortorder: "DESC"
+                });
+
+                // 3. Get History for specified (or default) items
+                let history = {};
+                const itemKeysToFetch = historyItemKeys || [
+                    'system.cpu.load[,avg1]',
+                    'vm.memory.size[pavailable]',
+                    'net.if.in[eth0]',
+                    'net.if.out[eth0]'
+                ];
+
+                const items = await api.getItems({
+                    hostids: [hostId],
+                    search: {
+                        key_: itemKeysToFetch
+                    },
+                    output: ['itemid', 'key_', 'value_type']
+                });
+
+                for (const item of items) {
+                    const itemHistory = await api.getHistory({
+                        itemids: [item.itemid],
+                        history: item.value_type,
+                        limit: 10,
+                        sortfield: "clock",
+                        sortorder: "DESC"
+                    });
+                    history[item.key_] = itemHistory;
+                }
+
+                // 4. Assemble the report
+                const report = {
+                    host: hostDetails,
+                    activeProblems: problems,
+                    recentHistory: history
+                };
+
+                return { content: [{ type: 'text', text: `Host Diagnostics Report for ${hostDetails.name}:\n${JSON.stringify(report, null, 2)}` }] };
+
+            } catch (e) {
+                logger.error('Error in zabbix_get_host_diagnostics:', e);
+                throw e;
+            }
+        }
+    );
+
+    // Tool: Compare Hosts
+    server.tool(
+        'zabbix_compare_hosts',
+        'Compares the configuration of two hosts and highlights the differences.',
+        {
+            hostIdentifierA: z.string().describe("The identifier for the first host (name, IP, or ID)."),
+            hostIdentifierB: z.string().describe("The identifier for the second host (name, IP, or ID).")
+        },
+        async ({ hostIdentifierA, hostIdentifierB }) => {
+            try {
+                const { hostId: hostIdA, error: errorA } = await resolveHostIdentifier(hostIdentifierA);
+                if (errorA) return { content: [{ type: 'text', text: `Error for Host A: ${errorA}` }] };
+
+                const { hostId: hostIdB, error: errorB } = await resolveHostIdentifier(hostIdentifierB);
+                if (errorB) return { content: [{ type: 'text', text: `Error for Host B: ${errorB}` }] };
+
+                const [hostA] = await api.getHosts({
+                    hostids: [hostIdA],
+                    selectParentTemplates: ['templateid', 'name'],
+                    selectMacros: 'extend',
+                    selectInterfaces: 'extend'
+                });
+
+                const [hostB] = await api.getHosts({
+                    hostids: [hostIdB],
+                    selectParentTemplates: ['templateid', 'name'],
+                    selectMacros: 'extend',
+                    selectInterfaces: 'extend'
+                });
+
+                if (!hostA || !hostB) {
+                    return { content: [{ type: 'text', text: "Could not find one or both hosts." }] };
+                }
+
+                // Normalize and sort for consistent comparison
+                const normalize = (host) => {
+                    // Sort arrays of objects by a key to ensure consistent order
+                    if (host.parentTemplates) host.parentTemplates.sort((a, b) => a.name.localeCompare(b.name));
+                    if (host.macros) host.macros.sort((a, b) => a.macro.localeCompare(b.macro));
+                    if (host.interfaces) host.interfaces.sort((a, b) => a.ip.localeCompare(b.ip));
+                    return host;
+                };
+
+                const strA = JSON.stringify(normalize(hostA), null, 2);
+                const strB = JSON.stringify(normalize(hostB), null, 2);
+
+                const differences = diff.createPatch('HostComparison.json', strA, strB, hostA.name, hostB.name);
+
+                return { content: [{ type: 'text', text: `Configuration difference between ${hostA.name} and ${hostB.name}:\n${differences}` }] };
+
+            } catch (e) {
+                logger.error('Error in zabbix_compare_hosts:', e);
+                throw e;
+            }
+        }
+    );
+}
+
+    // Tool: Audit Unmonitored Hosts
+    server.tool(
+        'zabbix_audit_unmonitored_hosts',
+        'Finds and reports hosts that are not being monitored correctly, including those set to unmonitored status or with availability errors.',
+        {
+            hostGroupIds: z.array(z.string()).optional().describe('Optional array of host group IDs to limit the audit to.')
+        },
+        async ({ hostGroupIds }) => {
+            try {
+                const params = {
+                    output: ['hostid', 'name', 'status', 'error', 'available'],
+                    ...(hostGroupIds && { groupids: hostGroupIds })
+                };
+
+                const allHosts = await api.getHosts(params);
+
+                const unmonitoredHosts = allHosts.filter(h => h.status === '1');
+                const availabilityErrors = allHosts.filter(h => h.available === '2');
+
+                const report = {
+                    unmonitoredHosts: unmonitoredHosts.map(h => ({ name: h.name, hostid: h.hostid, error: h.error })),
+                    hostsWithAvailabilityErrors: availabilityErrors.map(h => ({ name: h.name, hostid: h.hostid, error: h.error })),
+                    summary: {
+                        totalHostsChecked: allHosts.length,
+                        unmonitoredCount: unmonitoredHosts.length,
+                        availabilityErrorCount: availabilityErrors.length
+                    }
+                };
+
+                return { content: [{ type: 'text', text: `Unmonitored Hosts Audit Report:\n${JSON.stringify(report, null, 2)}` }] };
+
+            } catch (e) {
+                logger.error('Error in zabbix_audit_unmonitored_hosts:', e);
+                throw e;
+            }
+        }
+    );
+}
+
+    // Tool: Template Audit
+    server.tool(
+        'zabbix_template_audit',
+        'Analyzes template usage to find unlinked templates, hosts without templates, and potentially oversized templates.',
+        {
+            itemThreshold: z.number().int().optional().default(100).describe("The threshold for the number of items to consider a template 'oversized'."),
+            triggerThreshold: z.number().int().optional().default(50).describe("The threshold for the number of triggers to consider a template 'oversized'.")
+        },
+        async ({ itemThreshold, triggerThreshold }) => {
+            try {
+                const [allTemplates, allHosts] = await Promise.all([
+                    api.getTemplates({
+                        output: ['templateid', 'name'],
+                        selectHosts: ['hostid'],
+                        selectItems: 'count',
+                        selectTriggers: 'count'
+                    }),
+                    api.getHosts({
+                        output: ['hostid', 'name'],
+                        selectParentTemplates: ['templateid']
+                    })
+                ]);
+
+                const unlinkedTemplates = allTemplates.filter(t => t.hosts.length === 0);
+                const hostsWithoutTemplates = allHosts.filter(h => h.parentTemplates.length === 0);
+                const oversizedTemplates = allTemplates.filter(t => t.items > itemThreshold || t.triggers > triggerThreshold);
+
+                const report = {
+                    unlinkedTemplates: unlinkedTemplates.map(t => ({ name: t.name, templateid: t.templateid })),
+                    hostsWithoutTemplates: hostsWithoutTemplates.map(h => ({ name: h.name, hostid: h.hostid })),
+                    oversizedTemplates: oversizedTemplates.map(t => ({ name: t.name, templateid: t.templateid, itemCount: t.items, triggerCount: t.triggers })),
+                    summary: {
+                        totalTemplatesChecked: allTemplates.length,
+                        totalHostsChecked: allHosts.length,
+                        unlinkedTemplateCount: unlinkedTemplates.length,
+                        hostsWithoutTemplateCount: hostsWithoutTemplates.length,
+                        oversizedTemplateCount: oversizedTemplates.length
+                    }
+                };
+
+                return { content: [{ type: 'text', text: `Template Audit Report:\n${JSON.stringify(report, null, 2)}` }] };
+
+            } catch (e) {
+                logger.error('Error in zabbix_template_audit:', e);
+                throw e;
+            }
+        }
+    );
+}
+
+module.exports = { registerTools };

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -20,6 +20,7 @@ const configurationTools = require('./configuration');
 const serviceTools = require('./services');
 const intelligenceTools = require('./intelligence');
 const graphTools = require('./graphs');
+const analysisTools = require('./analysis');
 // Import other tool categories as they are created
 
 function registerAllTools(server) {
@@ -44,7 +45,8 @@ function registerAllTools(server) {
         { name: 'configuration', module: configurationTools },
         { name: 'services', module: serviceTools },
         { name: 'intelligence', module: intelligenceTools },
-        { name: 'graphs', module: graphTools }
+        { name: 'graphs', module: graphTools },
+        { name: 'analysis', module: analysisTools }
     ];
     
     for (const { name, module } of toolCategories) {


### PR DESCRIPTION
This commit introduces a new set of analysis tools to the Zabbix MCP server, designed to provide deeper insights into the monitored environment.

New Tools:
- `zabbix_get_host_diagnostics`: Provides a comprehensive diagnostic report for a single host.
- `zabbix_compare_hosts`: Compares the configuration of two hosts.
- `zabbix_audit_unmonitored_hosts`: Finds hosts that are not being monitored correctly.
- `zabbix_template_audit`: Analyzes template usage and identifies potential problems.

New Prompts:
- A new `NEW_PROMPTS.md` file has been added to document the new prompts that leverage these tools.